### PR TITLE
make OS.Time compatible with Mirage_time_lwt.S

### DIFF
--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -27,6 +27,8 @@ module Main : sig
 end
 
 module Time : sig
+  type +'a io = 'a Lwt.t
+
   val sleep_ns : int64 -> unit Lwt.t
   (** [sleep_ns d] Block the current thread for [n] nanoseconds. *)
 end


### PR DESCRIPTION
sorry, 3.0.6 broke this... see https://travis-ci.org/mirage/mirage/jobs/353339441 for details