### PR TITLE
Add appveyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+platform:
+  - x86
+
+environment:
+  FORK_USER: ocaml
+  FORK_BRANCH: master
+  CYG_ROOT: C:\cygwin64
+  PINS: "mirage-unix:."
+  PACKAGE: "mirage-unix"
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))
+
+build_script:
+  - call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\appveyor-opam.sh


### PR DESCRIPTION
This is the appveyor.yml from mirage-platform, see mirage/mirage-platform#203.

Signed-off-by: David Scott <dave@recoil.org>