### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-unix.opam
+++ b/mirage-unix.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build}
+  "dune"
   "lwt" {>= "2.4.3"}
   "logs"
   "io-page-unix" {>= "2.0.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.