### PR TITLE
Use the new mirage-runtime Hooks module to simplify the scheduler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     global:
         - TESTS=false
         - PACKAGE="mirage-unix"
+        - PINS="mirage-runtime:https://github.com/samoht/mirage.git#runtime-hooks"
     matrix:
         - OCAML_VERSION=4.07
         - OCAML_VERSION=4.06

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
         - PACKAGE="mirage-unix"
         - PINS="mirage-runtime:https://github.com/samoht/mirage.git#runtime-hooks"
     matrix:
+        - OCAML_VERSION=4.08
         - OCAML_VERSION=4.07
         - OCAML_VERSION=4.06
         - OCAML_VERSION=4.05
-        - OCAML_VERSION=4.04

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (name oS)
   (public_name mirage-unix)
-  (libraries lwt lwt.unix logs io-page-unix))
+  (libraries lwt lwt.unix logs mirage-runtime io-page-unix))

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -1,40 +1,42 @@
-open Lwt.Infix
+(* From lwt/src/unix/lwt_main.ml *)
+let rec run t =
+  (* Wakeup paused threads now. *)
+  Lwt.wakeup_paused ();
+  match Lwt.poll t with
+  | Some x -> x
+  | None ->
+    (* Call enter hooks. *)
+    Mirage_runtime.run_enter_iter_hooks ();
+    (* Do the main loop call. *)
+    Lwt_engine.iter (Lwt.paused_count () = 0);
+    (* Wakeup paused threads again. *)
+    Lwt.wakeup_paused ();
+    (* Call leave hooks. *)
+    Mirage_runtime.run_leave_iter_hooks ();
+    run t
 
-[@@@warning "-3"] (* due to Lwt_sequence *)
+(* If the platform doesn't have SIGPIPE, then Sys.set_signal will
+   raise an Invalid_argument exception. If the signal does not exist
+   then we don't need to ignore it, so it's safe to continue. *)
+let ignore_sigpipe () =
+  try Sys.(set_signal sigpipe Signal_ignore) with Invalid_argument _ -> ()
 
-let exit_hooks = Lwt_sequence.create ()
-let enter_hooks = Lwt_sequence.create ()
-
-let rec call_hooks hooks  =
-  match Lwt_sequence.take_opt_l hooks with
-    | None ->
-        Lwt.return_unit
-    | Some f ->
-        (* Run the hooks in parallel *)
-        let _ =
-          Lwt.catch f
-          (fun exn ->
-            Logs.warn (fun m -> m "call_hooks: exn %s" (Printexc.to_string exn));
-            Lwt.return_unit
-          ) in
-        call_hooks hooks
+let protect t =
+  Lwt.catch
+    (fun () -> t)
+    (fun e ->
+       Logs.err (fun m ->
+           m "main: %a\n%s" Fmt.exn e (Printexc.get_backtrace ()));
+       Lwt.return_unit)
 
 (* Main runloop, which registers a callback so it can be invoked
    when timeouts expire. Thus, the program may only call this function
    once and once only. *)
 let run t =
-  (* If the platform doesn't have SIGPIPE, then Sys.set_signal will
-     raise an Invalid_argument exception. If the signal does not exist
-     then we don't need to ignore it, so it's safe to continue. *)
-  (try Sys.(set_signal sigpipe Signal_ignore) with Invalid_argument _ -> ());
-  let t = call_hooks enter_hooks <&> t in
-  Lwt_main.run (
-    Lwt.catch
-      (fun () -> t)
-      (fun e -> Logs.err (fun m -> m "main: %s\n%s" (Printexc.to_string e) (Printexc.get_backtrace ())); Lwt.return_unit))
+  ignore_sigpipe ();
+  run (protect t)
 
-let () = at_exit (fun () -> run (call_hooks exit_hooks))
-let at_exit f = ignore (Lwt_sequence.add_l f exit_hooks)
-let at_enter f = ignore (Lwt_sequence.add_l f enter_hooks)
-let at_exit_iter f = ignore (Lwt_sequence.add_r f Lwt_main.leave_iter_hooks)
-let at_enter_iter f = ignore (Lwt_sequence.add_r f Lwt_main.enter_iter_hooks)
+let () =
+  at_exit (fun () ->
+      Lwt.abandon_wakeups ();
+      run (Mirage_runtime.run_exit_hooks ()))

--- a/lib/main.mli
+++ b/lib/main.mli
@@ -15,7 +15,3 @@
  *)
 
 val run : unit Lwt.t -> unit
-val at_exit : (unit -> unit Lwt.t) -> unit
-val at_enter : (unit -> unit Lwt.t) -> unit
-val at_exit_iter  : (unit -> unit) -> unit
-val at_enter_iter : (unit -> unit) -> unit

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -14,10 +14,6 @@ end
 
 module Main : sig
   val run : unit Lwt.t -> unit
-  val at_exit : (unit -> unit Lwt.t) -> unit
-  val at_enter : (unit -> unit Lwt.t) -> unit
-  val at_exit_iter  : (unit -> unit) -> unit
-  val at_enter_iter : (unit -> unit) -> unit
 end
 
 module Time : sig

--- a/mirage-unix.opam
+++ b/mirage-unix.opam
@@ -18,6 +18,7 @@ depends: [
   "dune" {build}
   "lwt" {>= "2.4.3"}
   "logs"
+  "mirage-runtime"
   "io-page-unix" {>= "2.0.0"}
 ]
 tags: "org:mirage"


### PR DESCRIPTION
The main loop is now much simpler, and it calls Lwt_engine directly.

See https://github.com/mirage/mirage/pull/1010