### PR TITLE
Prepare v4.0.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## v4.0.1 (2021-04-14)
 
 * Delete `io-page-unix` and use `io-page.2.4.0` instead
-  (@samoth, @dinosaure, #16)
+  (@samoht, @dinosaure, #16)
 
 ## v4.0.0 (2019-11-01)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v4.0.1 (2021-04-14)
+
+* Delete `io-page-unix` and use `io-page.2.4.0` instead
+  (@samoth, @dinosaure, #16)
+
 ## v4.0.0 (2019-11-01)
 
 * Use mirage-runtime hooks (at_enter_iter/at_exit_iter/at_exit), see mirage/mirage#1010 for details (#14 #15 by @samoht @dinosaure)

--- a/mirage-unix.opam
+++ b/mirage-unix.opam
@@ -8,14 +8,14 @@ doc:          "https://mirage.github.io/mirage-unix/doc"
 license:      "ISC"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"
+  "dune" {>= "1.11"}
   "lwt" {>= "2.4.3"}
   "duration"
   "mirage-runtime" {>= "3.7.0"}


### PR DESCRIPTION
It's a minor one when we don't really change anything. Needed for the compatibility between MirageOS 3 & MirageOS 4